### PR TITLE
Allow voku/html-min 5.0 for PHP 8.5 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	}],
 	"require": {
 		"silverstripe/cms": "^6",
-		"voku/html-min": "^4.5.0"
+		"voku/html-min": "^4.5.0 || ^5.0.0"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
## Summary

Updates the `voku/html-min` constraint to permit both 4.x and 5.x, unblocking PHP 8.5 compatibility for downstream consumers.

## Why

- `voku/html-min` 4.x pins `voku/simple_html_dom` to `~4.8.5`
- `voku/simple_html_dom` 4.8.x has implicit-nullable parameter declarations (`SimpleHtmlAttributes::toggle()`, the matching interface, `XmlDomParser::replaceTextWithCallback()`) — these emit `Deprecated: Implicitly marking parameter ... as nullable is deprecated` warnings under PHP 8.4 and 8.5 (deprecated in 8.4, scheduled for removal in 9.0)
- `voku/simple_html_dom` 5.0 has these explicitly declared as nullable — fully PHP 8.5 clean
- `voku/html-min` 5.0 requires `voku/simple_html_dom: ^5.0`, so allowing the major bump pulls the fixed library transitively

## Compatibility

- Constraint left as `^4.5.0 || ^5.0` rather than just `^5.0` so existing consumers still on 4.x aren't broken
- All public methods this package's `HTMLMinifier` calls on `HtmlMin` are preserved in 5.0 with compatible signatures (verified — every `do*` setter + `__construct` + `minify` is still there)
- `voku/html-min` 5.0 introduces some behavioural fixes (whitespace around inline tags `<b>`/`<em>`/`<i>`/`<strong>`/`<u>`, UTF-8 non-breaking space preservation, `<script type="application/ld+json">` whitespace handling) — these are upstream bug fixes, not regressions, but consumers who depend on exact whitespace bytes in minified output should smoke-test the upgrade
- `voku/html-min` 5.0 also adds `tedivm/jshrink ^1.8.1` as a transitive dep (used for the new opt-in `doMinifyJavaScript()` feature). This package doesn't invoke that method, so jshrink is dead weight at runtime — but it does appear in composer.lock

## Verification

\`php -l\` sweep across this package and its dependency tree under PHP 8.4 and PHP 8.5 (`php:8.4-cli` and `php:8.5-cli` Docker images): **zero deprecations**.

## What this fixes for downstream consumers

Without this change, consumers running PHP 8.5 (or 8.4 with `WP_DEBUG_LOG` capturing deprecations) see warnings every time HTML minification runs:

- `voku\helper\SimpleHtmlAttributes::toggle()` — implicit nullable on `$force`
- `voku\helper\SimpleHtmlAttributesInterface::toggle()` — matching interface signature
- `voku\helper\XmlDomParser::replaceTextWithCallback()` — implicit nullable on `$domNode`